### PR TITLE
Fix handling of logging param

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,15 +1,15 @@
 {
   "name": "ntqdm",
-  "version": "1.0.0",
+  "version": "2.0.0",
   "description": "tqdm for node",
   "main": "src/index.js",
   "scripts": {
-   "test": "mocha"
+    "test": "mocha"
   },
   "devDependencies": {
-   "istanbul": "0.3.5",
-   "mocha": "2.0.0"
- },
+    "istanbul": "0.3.5",
+    "mocha": "2.0.0"
+  },
   "repository": {
     "type": "git",
     "url": "https://github.com/jhedin/ntqdm.git"

--- a/src/index.js
+++ b/src/index.js
@@ -124,7 +124,7 @@ function tqdm(){
 			n++;
 			elapsed = Date.now() - start;
 			if(n - lastn >= params.minIter && elapsed - lastElapsed >= params.minInterval) {
-				if(params.logging) {
+				if(!params.logging) {
 					process.stdout.write("\u001b[1F\u001b[2K");
 				}
 				

--- a/test/test.js
+++ b/test/test.js
@@ -1,5 +1,5 @@
 var assert = require('assert');
-var tdqm = require('../')();
+var tdqm = require('../');
 
 describe('tqdm', function() {
   it('prints a progress bar, for long running for..of loops', function(done) {


### PR DESCRIPTION
As the docs say, only write each progress update on a new line if `logging` is set to true. In the past, the check was implemented in the wrong way.

Also made the test work again.